### PR TITLE
Pull  from Options Passed In

### DIFF
--- a/JS/src/index.js
+++ b/JS/src/index.js
@@ -16,9 +16,11 @@ let hookedSubProvider
 let globalSyncOptions = {}
 
 const Trust = {
-  init (rpcUrl, options, syncOptions) { 
-    const engine = new ProviderEngine()
-    const web3 = new Web3(engine)
+  init (options, syncOptions) { 
+    const engine = new ProviderEngine(),
+          web3 = new Web3(engine),
+          { rpcUrl } = options
+
     context.web3 = web3
     globalSyncOptions = syncOptions
 


### PR DESCRIPTION
[#762](https://github.com/TrustWallet/trust-wallet-ios/pull/762) got pulled in prematurely, this will let the new version work with the provider