### PR TITLE
Improve eth_sign compatibility

### DIFF
--- a/dist/trust-min.js
+++ b/dist/trust-min.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fa543e15a22d3c8c791cbc1f86d047408a584d170ecbf2ad80feb8c8d02d0975
-size 533658
+oid sha256:222a345166f9056a175b9290efc9a4694ffbf3892b620d4c12c6726a670cea35
+size 534729

--- a/dist/trust-min.js
+++ b/dist/trust-min.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:222a345166f9056a175b9290efc9a4694ffbf3892b620d4c12c6726a670cea35
-size 534729
+oid sha256:41ad79db8f78e8c50aeb46d628328f0a870570bee906f068e4a0ba7d9055d1ec
+size 534862

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import ProviderRpcError from "./error";
 import Utils from "./utils";
 import IdMapping from "./id_mapping";
 import { EventEmitter } from "events";
+import isUtf8 from 'isutf8';
 
 class TrustWeb3Provider extends EventEmitter {
   constructor(config) {
@@ -200,7 +201,13 @@ class TrustWeb3Provider extends EventEmitter {
   }
 
   eth_sign(payload) {
-    this.postMessage("signMessage", payload.id, {data: payload.params[1]});
+    const data = payload.params[1];
+    const buffer = Utils.hex2buffer(data);
+    if (isutf8(buffer)) {
+      this.postMessage("signPersonalMessage", payload.id, {data: data});
+    } else {
+      this.postMessage("signMessage", payload.id, {data: payload.params[1]});
+    }
   }
 
   personal_sign(payload) {

--- a/src/index.js
+++ b/src/index.js
@@ -202,11 +202,17 @@ class TrustWeb3Provider extends EventEmitter {
 
   eth_sign(payload) {
     const data = payload.params[1];
-    const buffer = Utils.hex2buffer(data);
-    if (isutf8(buffer)) {
-      this.postMessage("signPersonalMessage", payload.id, {data: data});
+    var buffer;
+    if ((typeof (data) === "string")) {
+      buffer = Utils.hexToBuffer(data);
     } else {
-      this.postMessage("signMessage", payload.id, {data: payload.params[1]});
+      buffer = Buffer.from(data);
+    }
+    const hex = buffer.toString('hex');
+    if (isUtf8(buffer)) {
+      this.postMessage("signPersonalMessage", payload.id, {data: hex});
+    } else {
+      this.postMessage("signMessage", payload.id, {data: hex});
     }
   }
 

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1124,11 +1124,44 @@
         "physical-cpu-count": "^2.0.0"
       }
     },
+    "@types/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "14.11.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+      "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
+      "dev": true
+    },
+    "@types/pbkdf2": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/q": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
       "dev": true
+    },
+    "@types/secp256k1": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
+      "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "abab": {
       "version": "2.0.0",
@@ -2473,6 +2506,15 @@
         }
       }
     },
+    "base-x": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
@@ -2505,6 +2547,12 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "blakejs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U=",
+      "dev": true
     },
     "bn.js": {
       "version": "4.11.8",
@@ -2659,6 +2707,26 @@
       "requires": {
         "caniuse-lite": "^1.0.30000844",
         "electron-to-chromium": "^1.3.47"
+      }
+    },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "dev": true,
+      "requires": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "dev": true,
+      "requires": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "bser": {
@@ -4816,6 +4884,61 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
+    "ethereum-cryptography": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "dev": true,
+      "requires": {
+        "@types/pbkdf2": "^3.0.0",
+        "@types/secp256k1": "^4.0.1",
+        "blakejs": "^1.1.0",
+        "browserify-aes": "^1.2.0",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "hash.js": "^1.1.7",
+        "keccak": "^3.0.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.1.2",
+        "scrypt-js": "^3.0.0",
+        "secp256k1": "^4.0.1",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "ethereumjs-util": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.5.tgz",
+      "integrity": "sha512-gLLZVXYUHR6pamO3h/+M1jzKz7qE20PKFyFKtq1PrIHA6wcLI96mDz96EMkkhXfrpk30rhpkw0iRnzxKhqaIdQ==",
+      "dev": true,
+      "requires": {
+        "@types/bn.js": "^4.11.3",
+        "bn.js": "^5.1.2",
+        "create-hash": "^1.1.2",
+        "ethereum-cryptography": "^0.1.3",
+        "ethjs-util": "0.1.6",
+        "rlp": "^2.2.4"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
+          "dev": true
+        }
+      }
+    },
+    "ethjs-util": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+      "dev": true,
+      "requires": {
+        "is-hex-prefixed": "1.0.0",
+        "strip-hex-prefix": "1.0.0"
+      }
+    },
     "events": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
@@ -6847,6 +6970,12 @@
         "is-extglob": "^1.0.0"
       }
     },
+    "is-hex-prefixed": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
+      "dev": true
+    },
     "is-html": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-html/-/is-html-1.1.0.tgz",
@@ -7656,6 +7785,24 @@
         "verror": "1.10.0"
       }
     },
+    "keccak": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+      "dev": true,
+      "requires": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+          "dev": true
+        }
+      }
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -7719,7 +7866,8 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
     },
     "lodash.clone": {
       "version": "4.5.0",
@@ -8061,6 +8209,12 @@
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
       "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==",
+      "dev": true
+    },
+    "node-gyp-build": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
       "dev": true
     },
     "node-int64": {
@@ -10755,6 +10909,15 @@
         "inherits": "^2.0.1"
       }
     },
+    "rlp": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+      "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.11.1"
+      }
+    },
     "rsvp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
@@ -11109,6 +11272,31 @@
       "dev": true,
       "requires": {
         "xmlchars": "^2.1.1"
+      }
+    },
+    "scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "dev": true
+    },
+    "secp256k1": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+      "dev": true,
+      "requires": {
+        "elliptic": "^6.5.2",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+          "dev": true
+        }
       }
     },
     "semver": {
@@ -11715,6 +11903,15 @@
       "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
+    },
+    "strip-hex-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+      "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+      "dev": true,
+      "requires": {
+        "is-hex-prefixed": "1.0.0"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -2476,8 +2476,7 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -2672,14 +2671,12 @@
       }
     },
     "buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "dev": true,
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
       "requires": {
         "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-equal": {
@@ -6524,8 +6521,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -7110,6 +7106,11 @@
       "requires": {
         "handlebars": "^4.0.3"
       }
+    },
+    "isutf8": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isutf8/-/isutf8-3.1.1.tgz",
+      "integrity": "sha512-5P2FgGyDsSnRMaLPVGVIgYgMxj50lBujvi5lsVgP1qvMWhxvkmVBWtPcIKgXw9j+/RnmxSvHg3e9tbDnPxx6dw=="
     },
     "jest": {
       "version": "23.6.0",
@@ -8099,6 +8100,17 @@
         "vm-browserify": "^1.0.1"
       },
       "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -21,7 +21,9 @@
   "author": "Trust <support@trustwalletapp.com>",
   "license": "MIT",
   "dependencies": {
+    "buffer": "^5.6.0",
     "events": "^3.2.0",
+    "isutf8": "^3.1.1",
     "lodash": "^4.17.20",
     "web3": "^0.20.7"
   },

--- a/src/package.json
+++ b/src/package.json
@@ -24,7 +24,6 @@
     "buffer": "^5.6.0",
     "events": "^3.2.0",
     "isutf8": "^3.1.1",
-    "lodash": "^4.17.20",
     "web3": "^0.20.7"
   },
   "devDependencies": {
@@ -32,6 +31,8 @@
     "babel-preset-env": "^1.7.0",
     "eslint": "^5.16.0",
     "jest": "^23.6.0",
-    "parcel-bundler": "^1.12.4"
+    "parcel-bundler": "^1.12.4",
+    "lodash": "^4.17.20",
+    "ethereumjs-util": "^7.0.5"
   }
 }

--- a/src/tests/test.js
+++ b/src/tests/test.js
@@ -6,13 +6,21 @@
 
 "use strict";
 
+var ethUtil = require('ethereumjs-util')
 require("../index");
 const Trust = window.Trust;
 const Web3 = require("web3");
-const config = {
-  address: "0x5Ee066cc1250E367423eD4Bad3b073241612811f",
+
+const mainnet = {
+  address: "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F",
   chainId: 1,
-  rpcUrl: process.env.INFURA_API_KEY ? `https://mainnet.infura.io/v3/${process.env.INFURA_API_KEY}` : ""
+  rpcUrl: "https://mainnet.infura.io/v3/6e822818ec644335be6f0ed231f48310"
+};
+
+const ropsten = {
+  address: "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F",
+  chainId: 3,
+  rpcUrl: "https://ropsten.infura.io/apikey",
 };
 
 describe("TrustWeb3Provider constructor tests", () => {
@@ -27,7 +35,7 @@ describe("TrustWeb3Provider constructor tests", () => {
       chainId: 1,
       rpcUrl: ""
     });
-    const address = "0x5Ee066cc1250E367423eD4Bad3b073241612811f";
+    const address = mainnet.address
     expect(provider.address).toBe("");
 
     provider.setAddress(address);
@@ -36,16 +44,7 @@ describe("TrustWeb3Provider constructor tests", () => {
   });
 
   test("test setConfig", done => {
-    const mainnet = {
-      address: "0xbE74f965AC1BAf5Cc4cB89E6782aCE5AFf5Bd4db",
-      chainId: 1,
-      rpcUrl: "https://mainnet.infura.io/apikey"
-    };
-    const ropsten = {
-      address: "0xbE74f965AC1BAf5Cc4cB89E6782aCE5AFf5Bd4db",
-      chainId: 3,
-      rpcUrl: "https://ropsten.infura.io/apikey",
-    };
+
     const provider = new Trust(ropsten);
     const web3 = new Web3(provider);
 
@@ -65,11 +64,6 @@ describe("TrustWeb3Provider constructor tests", () => {
   });
 
   test("test eth_chainId", done => {
-    const ropsten = {
-      address: "0xbE74f965AC1BAf5Cc4cB89E6782aCE5AFf5Bd4db",
-      chainId: 3,
-      rpcUrl: "https://ropsten.infura.io/apikey",
-    };
     const provider = new Trust(ropsten);
     const web3 = new Web3(provider);
 
@@ -90,9 +84,9 @@ describe("TrustWeb3Provider constructor tests", () => {
   });
 
   test("test eth_accounts", done => {
-    const provider = new Trust(config);
+    const provider = new Trust(mainnet);
     const web3 = new Web3(provider);
-    const addresses = ["0x5ee066cc1250e367423ed4bad3b073241612811f"];
+    const addresses = ["0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f"];
 
     web3.eth.getAccounts((error, accounts) => {
       expect(accounts).toEqual(addresses);
@@ -109,4 +103,29 @@ describe("TrustWeb3Provider constructor tests", () => {
       done();
     });
   });
-});
+
+  test("test eth_sign", done => {
+    const provider = new Trust(mainnet);
+    const web3 = new Web3(provider);
+    const addresses = ["0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f"];
+    const signed = "0x730ec377cfc7090e08366fad4758aad721dbb51e187efe45426a7e56d1ff053947ab1a7b0bd7b138c48a9f3d3b92bd83f4265abbe9876930faaf7fbb980b219d1c";
+
+    window.webkit = {
+      messageHandlers: {
+        signMessage: {
+          postMessage: (message) => {
+            provider.sendResponse(message.id, signed);
+          }
+        }
+      }
+    }
+
+    var hash = ethUtil.keccak256(Buffer.from("An amazing message, for use with MetaMask!", "utf8"));
+    var hex = "0x" + hash.toString("hex");
+    web3.eth.sign(addresses[0], hex, (err, result) => {
+      expect(result).toEqual(signed);
+      done();
+    });
+  });
+
+}); // describe()

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,8 @@
 
 "use strict";
 
+import { Buffer } from 'buffer';
+
 class Utils {
   static genId() {
     return new Date().getTime() + Math.floor(Math.random() * 1000);
@@ -35,6 +37,14 @@ class Utils {
     }
     let hexString = int.toString(16);
     return "0x" + hexString;
+  }
+
+  static hexToBuffer(str) {
+    return Buffer.from(str.replace('0x', ''), 'hex');
+  }
+
+  static bufferToHex(buf) {
+    return Buffer.from(buf).toString('hex');
   }
 }
 


### PR DESCRIPTION
Fix signature when signing with `Web3Provider` from `ethers.js`

```js
import { Web3Provider } from '@ethersproject/providers'; // "@ethersproject/providers": "^5.0.9",
async signMessage() {
    await window.ethereum.enable();
    const web3 = new Web3Provider(window.ethereum);
    const signer = web3.getSigner();
    const sig = await signer.signMessage("0x879a053d4800c6354e76c7985a865d2922c82fb5b3f4577b2fe08b998954f2e0");
    console.log(sig);
}
```