### PR TITLE
Adding guard if an iframe doesn't have an ethereum property

### DIFF
--- a/dist/trust-min.js
+++ b/dist/trust-min.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:05dae3f1464ca422c0fc18856ebaa4176bac21dc56b0677509feffb8e5e95456
-size 780626
+oid sha256:54ae7b6d256bc5f437eec9848c1d86622dbe70fc3de4e8572a3ce6a76cadbb56
+size 781375

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ class TrustWeb3Provider extends EventEmitter {
     this.ready = !!address;
     for (var i = 0; i < window.frames.length; i++) {
       const frame = window.frames[i];
-      if (frame.ethereum.isTrust) {
+      if (frame.ethereum && frame.ethereum.isTrust) {
         frame.ethereum.address = lowerAddress;
         frame.ethereum.ready = !!address;
       }


### PR DESCRIPTION
We are seeing lots of these errors in our Dapp (Bidali) logs from this because we have a support widget in our dapp that loads an iframe and it doesn't have an ethereum property so it throws a `Cannot read property 'isTrust' of undefined` error. 

I had mentioned this to @vikmeup but then forgot to follow up or put up a PR.