### PR TITLE
Add try/catch for messageToBuffer

### DIFF
--- a/dist/trust-min.js
+++ b/dist/trust-min.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:353af50d6cda651dceb52167ca8909e84e1b5f03c5cae4bd9358ec17891abd48
-size 780638
+oid sha256:6237a28f928210863ab9cff0f7f17db255c51227a6a44aedb6fd167181fd8870
+size 780735

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
   - SwiftProtobuf (1.17.0)
-  - TrustWalletCore (2.6.9):
-    - TrustWalletCore/Core (= 2.6.9)
-  - TrustWalletCore/Core (2.6.9):
+  - TrustWalletCore (2.6.16):
+    - TrustWalletCore/Core (= 2.6.16)
+  - TrustWalletCore/Core (2.6.16):
     - TrustWalletCore/Types
-  - TrustWalletCore/Types (2.6.9):
+  - TrustWalletCore/Types (2.6.16):
     - SwiftProtobuf
   - TrustWeb3Provider (0.4.0)
 
@@ -23,7 +23,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   SwiftProtobuf: 9c85136c6ba74b0a1b84279dbf0f6db8efb714e0
-  TrustWalletCore: b7f1b813a881fb6ad1a54bb5b9348f917dbf9afc
+  TrustWalletCore: 9d3842328ccb07c05abaf7e1cb2c19bdc3d52331
   TrustWeb3Provider: c4fd1102867679e39224abf4449748cb4bd2a3a3
 
 PODFILE CHECKSUM: 8d19f94c2edff45b1a7b1dbc9915f8746172e56a

--- a/src/utils.js
+++ b/src/utils.js
@@ -41,11 +41,15 @@ class Utils {
 
   // message: Bytes | string
   static messageToBuffer(message) {
-    var buffer;
-    if ((typeof (message) === "string")) {
-      buffer = Buffer.from(message.replace("0x", ""), "hex");
-    } else {
-      buffer = Buffer.from(message);
+    var buffer = Buffer.from([]);
+    try {
+      if ((typeof (message) === "string")) {
+        buffer = Buffer.from(message.replace("0x", ""), "hex");
+      } else {
+        buffer = Buffer.from(message);
+      }
+    } catch (err) {
+      console.log(`messageToBuffer error: ${err}`);
     }
     return buffer;
   }


### PR DESCRIPTION
Fixes https://github.com/trustwallet/trust-web3-provider/issues/163, `Buffer.from` might throw exception

How to test:
1. Open https://wallet.matic.network/login/
2. Tap Metamask

<img src=https://user-images.githubusercontent.com/360470/126802596-2dafc074-7108-482d-b1d5-a699b38c01a7.png width=45% />
