### PR TITLE
fix: call _request with wrong wrapResult within sendAsync

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,7 @@ class TrustWeb3Provider extends EventEmitter {
       that = window.ethereum;
     }
     if (Array.isArray(payload)) {
-      Promise.all(payload.map(that._request.bind(that)))
+      Promise.all(payload.map((_payload) => that._request(_payload)))
         .then((data) => callback(null, data))
         .catch((error) => callback(error, null));
     } else {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -23,7 +23,8 @@
         "eslint": "^8.7.0",
         "ethereumjs-util": "^7.0.5",
         "jest": "^27.4.7",
-        "uglify-js": "^3.15.0"
+        "uglify-js": "^3.15.0",
+        "whatwg-fetch": "^3.6.2"
       },
       "engines": {
         "node": ">=14"
@@ -9318,6 +9319,12 @@
         "iconv-lite": "0.4.24"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
+    },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -16702,6 +16709,12 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/src/package.json
+++ b/src/package.json
@@ -32,7 +32,8 @@
     "eslint": "^8.7.0",
     "ethereumjs-util": "^7.0.5",
     "jest": "^27.4.7",
-    "uglify-js": "^3.15.0"
+    "uglify-js": "^3.15.0",
+    "whatwg-fetch": "^3.6.2"
   },
   "jest": {
     "verbose": true,

--- a/src/tests/test.js
+++ b/src/tests/test.js
@@ -8,6 +8,7 @@
 
 var ethUtil = require("ethereumjs-util");
 require("../index");
+require("whatwg-fetch");
 const Web3 = require("web3");
 const trustwallet = window.trustwallet;
 
@@ -26,7 +27,7 @@ const ropsten = {
 const bsc = {
   address: "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F",
   chainId: 56,
-  rpcUrl: "https://bsc-dataseed1.binance.orge",
+  rpcUrl: "https://bsc-dataseed1.binance.org",
 };
 
 describe("TrustWeb3Provider constructor tests", () => {
@@ -177,5 +178,32 @@ describe("TrustWeb3Provider constructor tests", () => {
       expect(result).toEqual(signed);
       done();
     });
+  });
+
+  test("test batched sendAsync", (done) => {
+    const provider = new trustwallet.Provider(bsc);
+    const web3 = new Web3(provider);
+    const request = [
+      {jsonrpc: "2.0", id: 11, method: "eth_call", params: [{data: "0x06fdde03", to: "0xe9e7cea3dedca5984780bafc599bd69add087d56"}, "latest"]},
+      {jsonrpc: "2.0", id: 12, method: "eth_call", params: [{data: "0x313ce567", to: "0xe9e7cea3dedca5984780bafc599bd69add087d56"}, "latest"]}
+    ];
+    const expectedResult = [
+      {
+        jsonrpc: "2.0",
+        id: 11,
+        result: "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000a4255534420546f6b656e00000000000000000000000000000000000000000000"
+      },
+      {
+        jsonrpc: "2.0",
+        id: 12,
+        result: "0x0000000000000000000000000000000000000000000000000000000000000012"
+      }
+    ];
+    web3.currentProvider.sendAsync(request,
+      (error, result) => {
+        expect(result).toEqual(expectedResult);
+        done();
+      }
+    );
   });
 }); // end of top describe()


### PR DESCRIPTION
**Problem:**
```js
Promise.all(payload.map(that._request.bind(that)))
```
When using the above code, it calls `_request` with a wrong wrapResult, the index of the payload.
