### PR TITLE
Disable generation of the BuildConfig class

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -19,3 +19,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+# Disable generation of the BuildConfig class
+android.defaults.buildfeatures.buildconfig=false


### PR DESCRIPTION
This class is useless for library's clients

<img width="440" alt="Screen Shot 2022-05-24 at 13 24 57" src="https://user-images.githubusercontent.com/17238054/169963124-6fd4d6ee-f12b-479e-b88a-654453ef59a0.png">

<img width="623" alt="Screen Shot 2022-05-24 at 13 25 28" src="https://user-images.githubusercontent.com/17238054/169963097-971f85d6-da7e-4576-9c8e-48291c366f42.png">