### PR TITLE
Fix personal_sign compatibility issues

### DIFF
--- a/src/ethereum_provider.js
+++ b/src/ethereum_provider.js
@@ -254,7 +254,12 @@ class TrustWeb3Provider extends BaseProvider {
   }
 
   personal_sign(payload) {
-    const message = payload.params[0];
+    var message;
+    if (this.address === payload.params[0]) {
+      message = payload.params[1];
+    } else {
+      message = payload.params[0];
+    }
     const buffer = Utils.messageToBuffer(message);
     if (buffer.length === 0) {
       // hex it


### PR DESCRIPTION
Compatible with various `personal_sign` calling methods.

[MetaMask Test Dapp](https://metamask.github.io/test-dapp/)
```
{
    "id": 1669276639299,
    "method": "personal_sign",
    "params":
    [
        "0x4578616d706c652060706572736f6e616c5f7369676e60206d657373616765",
        "0x0000000000000000000000000000000000000000",
        "Example password"
    ]
}
```

[MOBOX](https://www.mobox.io/#/)
```
{
    "id": 1669276574176,
    "method": "personal_sign",
    "params":
    [
        "0x0000000000000000000000000000000000000000",
        "wallet_login_27821276"
    ]
}
```