### PR TITLE
Update package.json to prevent private package by scoping

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "npx browserify index.js -t [ babelify --presets [ @babel/preset-env ] ] | uglifyjs > ../dist/trust-min.js",
-    "publish-package": "mkdir -p dist && cp ../dist/trust-min.js ./dist/trust-min.js && npm publish",
+    "publish-package": "mkdir -p dist && cp ../dist/trust-min.js ./dist/trust-min.js && npm publish --access public",
     "lint": "eslint . --fix",
     "test": "jest",
     "lfs-fix": "git rm --cached --force ../dist/trust-min.js && git add ../dist/trust-min.js"


### PR DESCRIPTION
Prevent publishing package as private (since is scoped by org)