### PR TITLE
feat: Adding support for Solana versioned txs

### DIFF
--- a/dist/trust-min.js
+++ b/dist/trust-min.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ae63c0d8413474380a00772ff5fb74215b38c44b32fb7c96dca693ccf447c2f4
-size 903698
+oid sha256:fbae3533eb54d7b313262504a197399bb70b4a3840f5eda8626a7b37a2a4518a
+size 902789

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -3831,9 +3831,9 @@
       "dev": true
     },
     "node_modules/cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
     "node_modules/core-js-compat": {
@@ -12901,9 +12901,9 @@
       }
     },
     "cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
     "core-js-compat": {


### PR DESCRIPTION
### Supporting V0 Transaction Sign

- Now the transaction version is passed down to the signRawTransaction method with `version = 'legacy' | 0`
- Signature verification enabled for legacy txs
- Bump cookiejar for security

###  Apps 
You should handle and update logic to reject or support versioned transaction, you can check for version == 0. Previously the provider failed and the request was not sent to the Wallet, after this update the request will be sent.