### PR TITLE
feat: Allow multi Solana transactions in a single request

### DIFF
--- a/dist/trust-min.js
+++ b/dist/trust-min.js
@@ -1,4 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9c769319b786af37983bec5ab595146a7390cd3b9183fc0b5bbc6c8315d0c058
-size 904561
-
+oid sha256:9a53075ea4162e44b48ffb7803fea022b7a7778f6871a65cb7e7199b07d15bc2
+size 905614

--- a/src/solana_provider.js
+++ b/src/solana_provider.js
@@ -61,6 +61,23 @@ class TrustSolanaWeb3Provider extends BaseProvider {
     });
   }
 
+  mapSignedTransaction(tx, signatureEncoded) {
+    const version = typeof tx.version !== "number" ? "legacy" : tx.version;
+    const signature = bs58.decode(signatureEncoded);
+
+    tx.addSignature(this.publicKey, signature);
+
+    if (version === "legacy" && !tx.verifySignatures()) {
+      throw new ProviderRpcError(4300, "Invalid signature");
+    }
+
+    if (this.isDebug) {
+      console.log(`==> signed single ${JSON.stringify(tx)}`);
+    }
+
+    return tx;
+  }
+
   signTransaction(tx) {
     const data = JSON.stringify(tx);
     const version = typeof tx.version !== "number" ? "legacy" : tx.version;
@@ -70,20 +87,9 @@ class TrustSolanaWeb3Provider extends BaseProvider {
     );
 
     return this._request("signRawTransaction", { data, raw, version })
-      .then((signatureEncoded) => {
-        const signature = bs58.decode(signatureEncoded);
-        tx.addSignature(this.publicKey, signature);
-
-        if (version === "legacy" && !tx.verifySignatures()) {
-          throw new ProviderRpcError(4300, "Invalid signature");
-        }
-
-        if (this.isDebug) {
-          console.log(`==> signed single ${JSON.stringify(tx)}`);
-        }
-
-        return tx;
-      })
+      .then((signatureEncoded) =>
+        this.mapSignedTransaction(tx, signatureEncoded)
+      )
       .catch((error) => {
         console.log(`<== Error: ${error}`);
       });
@@ -95,28 +101,22 @@ class TrustSolanaWeb3Provider extends BaseProvider {
 
   signAllTransactionsV2(txs) {
     return this._request("signRawTransactionMulti", {
-      transactions: txs.map((tx) => ({
-        data: JSON.stringify(tx),
-        raw: bs58.encode(tx.serializeMessage()),
-      })),
+      transactions: txs.map((tx) => {
+        const data = JSON.stringify(tx);
+        const version = typeof tx.version !== "number" ? "legacy" : tx.version;
+
+        const raw = bs58.encode(
+          version === "legacy" ? tx.serializeMessage() : tx.serialize()
+        );
+
+        return { data, raw, version };
+      }),
     })
-      .then((signatureEncoded) => {
-        return signatureEncoded.map((tx) => {
-          const signature = bs58.decode(signatureEncoded);
-
-          tx.addSignature(this.publicKey, signature);
-
-          if (!tx.verifySignatures()) {
-            throw new ProviderRpcError(4300, "Invalid signature");
-          }
-
-          if (this.isDebug) {
-            console.log(`==> signed single ${JSON.stringify(tx)}`);
-          }
-
-          return tx;
-        });
-      })
+      .then((signaturesEncoded) =>
+        signaturesEncoded.map((signature, i) =>
+          this.mapSignedTransaction(txs[i], signature)
+        )
+      )
       .catch((error) => {
         console.log(`<== Error: ${error}`);
       });
@@ -163,8 +163,9 @@ class TrustSolanaWeb3Provider extends BaseProvider {
         case "signMessage":
           return this.postMessage("signMessage", id, payload);
         case "signRawTransaction":
-        case "signRawTransactionMulti":
           return this.postMessage("signRawTransaction", id, payload);
+        case "signRawTransactionMulti":
+          return this.postMessage("signRawTransactionMulti", id, payload);
         case "requestAccounts":
           return this.postMessage("requestAccounts", id, {});
         default:


### PR DESCRIPTION
- Using the existing approach creates multiple popups in the extension, by adding a new signAllTransactionsV2 and overwriting signAllTransaction inside the extension, solves the issue without breaking other wallets.