### PR TITLE
fix bug switch chain in TrustWallet Extention to Uniswap

### DIFF
--- a/src/ethereum_provider.js
+++ b/src/ethereum_provider.js
@@ -224,7 +224,7 @@ class TrustWeb3Provider extends BaseProvider {
   }
 
   emitChainChanged(chainId) {
-    this.emit("chainChanged", chainId);
+    this.emit("chainChanged", "0x" + chainId.toString(16));
     this.emit("networkChanged", chainId);
   }
 


### PR DESCRIPTION
When I switched chain in TrustWallet Extention to Uniswap web, Uniswap didn't receive Chain change information, this PR is helping to handle that, please check PR