### PR TITLE
Support Solana Transaction "Versioned"

### DIFF
--- a/src/solana_provider.js
+++ b/src/solana_provider.js
@@ -87,7 +87,7 @@ class TrustSolanaWeb3Provider extends BaseProvider {
     const version = typeof tx.version !== "number" ? "legacy" : tx.version;
 
     const raw = bs58.encode(
-      version === "legacy" ? tx.serializeMessage() : tx.serialize()
+      version === "legacy" ? tx.serializeMessage() : version === 0 ? tx.message.serialize() : tx.serialize()
     );
 
     return this._request("signRawTransaction", { data, raw, version })
@@ -110,7 +110,7 @@ class TrustSolanaWeb3Provider extends BaseProvider {
         const version = typeof tx.version !== "number" ? "legacy" : tx.version;
 
         const raw = bs58.encode(
-          version === "legacy" ? tx.serializeMessage() : tx.serialize()
+          version === "legacy" ? tx.serializeMessage() : version === 0 ? tx.message.serialize() : tx.serialize()
         );
 
         return { data, raw, version };


### PR DESCRIPTION
Some DApps ([Jupiter](https://jup.ag), KyberSwap) of Solana already support [Versioned](https://docs.solana.com/developing/versioned-transactions). But I noticed that Jupiter seems to be checking that if logged in with Phantom wallet the Transaction will be structured as `Versioned` and if logged in with Trust wallet it will use `Legacy`. So I figured out how to be able to sign `Transaction Versioned`, and luckily Solana has the solution for it [Here - Versioned Transaction Test](https://github.com/solana-labs/solana-web3.js/blob/73932e086e9458a3bce32d7688fbf8304e4a4c51/packages/library-legacy/test/transaction.test.ts#L1155).
Please review and check PR. Thank you