### PR TITLE
chore: Refactoring RPC response parsing for cosmos

### DIFF
--- a/dist/trust-min.js
+++ b/dist/trust-min.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e7cfcf1c7453298f3998ec5bdd77a4ace4a029b71027135a29b8004cc36fb694
-size 906477
+oid sha256:df8966810f0970b613ddc5fc3440fc1d6bfca9c7538df35b9b41d0e6873d83a1
+size 906614

--- a/src/cosmos_provider.js
+++ b/src/cosmos_provider.js
@@ -61,21 +61,25 @@ export class TrustCosmosWeb3Provider extends BaseProvider {
     return this._request("signAmino", {
       chainId: chainId,
       sign_doc: signDoc,
-    }).then((signatures) => {
-      return { signed: signDoc, signature: JSON.parse(signatures)[0] };
+    }).then((response) => {
+      const { signed, signature } = JSON.parse(response);
+      return { signed, signature };
     });
   }
 
   signDirect(chainId, signerAddress, signDoc) {
     const object = {
-      body_bytes: Utils.bufferToHex(signDoc.bodyBytes),
-      auth_info_bytes: Utils.bufferToHex(signDoc.authInfoBytes),
+      bodyBytes: Utils.bufferToHex(signDoc.bodyBytes),
+      authInfoBytes: Utils.bufferToHex(signDoc.authInfoBytes),
     };
+
     return this._request("signDirect", {
+      signerAddress,
       chainId: chainId,
       sign_doc: object,
-    }).then((signatures) => {
-      return { signed: signDoc, signature: JSON.parse(signatures)[0] };
+    }).then((response) => {
+      const { signature } = JSON.parse(response);
+      return { signed: signDoc, signature };
     });
   }
 
@@ -83,13 +87,14 @@ export class TrustCosmosWeb3Provider extends BaseProvider {
     const buffer = Buffer.from(data);
     const hex = Utils.bufferToHex(buffer);
 
-    return this._request("signArbitrary", { chainId: chainId, data: hex }).then(
-      (result) => {
-        const signature = JSON.parse(result)[0].signature;
-        const signDoc = {};
-        return { signDoc, signature };
-      }
-    );
+    return this._request("signArbitrary", {
+      chainId: chainId,
+      data: hex,
+      signerAddress,
+    }).then((response) => {
+      const signDoc = {};
+      return { signDoc, signature: response };
+    });
   }
 
   sendTx(chainId, tx, mode) {


### PR DESCRIPTION
### Small refactor
This refactor intends to make it easy to handle RPC response of wallets by returning an object after signAmino with both signed and signature.

Also enforces camelCase for parameters sent to wallets to enhance consistency. 