### PR TITLE
fix: Send serialized message

### DIFF
--- a/dist/trust-min.js
+++ b/dist/trust-min.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1908e726093b70351e892691257436af0f1a424405c4f770890ac5619331fd0d
-size 1689910
+oid sha256:ac8a336e7b836a0a95bddcbc3abeb5f82e9f7c8a5dba882d0662bbf5ae52ff2f
+size 1690094

--- a/src/solana_provider.js
+++ b/src/solana_provider.js
@@ -91,7 +91,14 @@ class TrustSolanaWeb3Provider extends BaseProvider {
       })
     ).toString("base64");
 
-    return this._request("signRawTransaction", { data, raw, version })
+    const rawMessage = Buffer.from(tx.message.serialize()).toString("base64");
+
+    return this._request("signRawTransaction", {
+      data,
+      raw,
+      rawMessage,
+      version,
+    })
       .then((signatureEncoded) =>
         this.mapSignedTransaction(tx, signatureEncoded)
       )
@@ -110,6 +117,10 @@ class TrustSolanaWeb3Provider extends BaseProvider {
         const data = JSON.stringify(tx);
         const version = tx.version;
 
+        const rawMessage = Buffer.from(tx.message.serialize()).toString(
+          "base64"
+        );
+
         const raw = Buffer.from(
           tx.serialize({
             requireAllSignatures: false,
@@ -117,7 +128,7 @@ class TrustSolanaWeb3Provider extends BaseProvider {
           })
         ).toString("base64");
 
-        return { data, raw, version };
+        return { data, raw, rawMessage, version };
       }),
     })
       .then((signaturesEncoded) =>


### PR DESCRIPTION
Send rawMessage so apps don't have to unserialize transaction to use .getMessage()