### PR TITLE
fix: Verify chainId only if present in domain

### DIFF
--- a/src/ethereum_provider.js
+++ b/src/ethereum_provider.js
@@ -315,7 +315,10 @@ class TrustWeb3Provider extends BaseProvider {
 
     const { chainId } = message.domain || {};
 
-    if (!chainId || Number(chainId) !== Number(this.chainId)) {
+    if (
+      typeof chainId !== "undefined" &&
+      Number(chainId) !== Number(this.chainId)
+    ) {
       throw new Error(
         "Provided chainId does not match the currently active chain"
       );


### PR DESCRIPTION
According to the EIP chainId is optional