### PR TITLE
feat: Adding support for Ton

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "cSpell.words": [
+    "Bounceable",
     "outdir",
     "Parens",
     "pmqjw",

--- a/packages/ton/MobileAdapter.ts
+++ b/packages/ton/MobileAdapter.ts
@@ -1,0 +1,65 @@
+import { TonProvider } from './TonProvider';
+
+/**
+ * Adapting some requests to legacy mobile API
+ *
+ * This adapter provides the APIs with the method names and params the extension and mobile are
+ * ready to handle
+ */
+export class MobileAdapter {
+  provider: TonProvider;
+
+  constructor(provider: TonProvider) {
+    this.provider = provider;
+  }
+
+  async request<T>(method: string, params?: unknown[] | object): Promise<T> {
+    switch (method) {
+      case 'tonConnect_connect':
+      case 'tonConnect_reconnect': {
+        const res = await this.provider.internalRequest<string>(
+          'requestAccounts',
+          params,
+        );
+        return JSON.parse(res);
+      }
+
+      case 'ton_rawSign':
+        return this.provider.internalRequest<T>('signMessage', params);
+
+      case 'ton_sendTransaction':
+      case 'tonConnect_sendTransaction':
+        return this.provider.internalRequest<T>('signTransaction', params);
+
+      case 'ton_requestAccounts': {
+        const res = await this.provider.internalRequest<string>(
+          'requestAccounts',
+          params,
+        );
+
+        const [{ nonBounceable }] = JSON.parse(res);
+        return [nonBounceable] as T;
+      }
+
+      case 'ton_requestWallets': {
+        const res = await this.provider.internalRequest<string>(
+          'requestAccounts',
+          params,
+        );
+
+        const [{ nonBounceable, publicKey }] = JSON.parse(res);
+
+        return [
+          {
+            address: nonBounceable,
+            publicKey,
+            version: this.provider.version,
+          },
+        ] as T;
+      }
+
+      default:
+        return this.provider.internalRequest(method, params);
+    }
+  }
+}

--- a/packages/ton/README.md
+++ b/packages/ton/README.md
@@ -1,0 +1,41 @@
+# Trust Web3 Provider
+
+```
+    ___       ___       ___
+   /\  \     /\  \     /\__\
+   \:\  \   /::\  \   /:| _|_
+   /::\__\ /:/\:\__\ /::|/\__\
+  /:/\/__/ \:\/:/  / \/|::/  /
+  \/__/     \::/  /    |:/  /
+             \/__/     \/__/
+```
+
+### Ton JavaScript Provider Implementation
+
+### Config Object
+
+```typescript
+const config: {
+  isTrust?: boolean;
+  disableMobileAdapter?: boolean;
+  version?: string;
+} = {};
+```
+
+### Usage
+
+```typescript
+const ton = new TonProvider(config);
+```
+
+### Bridge usage
+
+```typescript
+const bridgeConfig: {
+  isWalletBrowser: boolean;
+  walletInfo: WalletInfo;
+  deviceInfo: DeviceInfo;
+} = {};
+
+const bridge = new TonBridge(ton, bridgeConfig);
+```

--- a/packages/ton/TonBridge.ts
+++ b/packages/ton/TonBridge.ts
@@ -1,0 +1,166 @@
+import { TonConnectError } from './exceptions/TonConnectError';
+import { TonProvider } from './TonProvider';
+import {
+  AppRequest,
+  ConnectEvent,
+  ConnectEventError,
+  ConnectItemReply,
+  ConnectRequest,
+  DeviceInfo,
+  TonConnectBridge,
+  TonConnectCallback,
+  WalletEvent,
+  WalletInfo,
+  WalletResponse,
+  WalletResponseError,
+} from './types/TonBridge';
+
+const formatConnectEventError = (error: TonConnectError): ConnectEventError => {
+  return {
+    event: 'connect_error',
+    payload: {
+      code: error.code ?? 0,
+      message: error.message,
+    },
+  };
+};
+
+/**
+ * Ton bridge implementation
+ *
+ * Based on https://docs.ton.org/develop/dapps/ton-connect/protocol & open mask
+ */
+export class TonBridge implements TonConnectBridge {
+  deviceInfo!: DeviceInfo;
+  walletInfo?: WalletInfo | undefined;
+  protocolVersion: number = 2;
+  isWalletBrowser: boolean = true;
+
+  private provider!: TonProvider;
+  private callbacks: TonConnectCallback[] = [];
+
+  constructor(
+    config: {
+      isWalletBrowser: boolean;
+      walletInfo: WalletInfo;
+      deviceInfo: DeviceInfo;
+    },
+    provider: TonProvider,
+  ) {
+    if (config) {
+      if (typeof config.isWalletBrowser !== 'undefined') {
+        this.isWalletBrowser = config.isWalletBrowser;
+      }
+
+      if (config.walletInfo) {
+        this.walletInfo = config.walletInfo;
+      }
+
+      if (config.deviceInfo) {
+        this.deviceInfo = config.deviceInfo;
+      }
+    }
+
+    this.provider = provider;
+  }
+
+  /**
+   * Connect
+   * @param protocolVersion
+   * @param message
+   * @returns
+   */
+  async connect(
+    protocolVersion: number,
+    message: ConnectRequest,
+  ): Promise<ConnectEvent> {
+    if (protocolVersion > this.protocolVersion) {
+      new TonConnectError('Unsupported protocol version', 1);
+    }
+
+    const items = await this.provider.send<ConnectItemReply[]>(
+      'tonConnect_connect',
+      message,
+    );
+
+    return this.emit({
+      event: 'connect',
+      payload: { items, device: this.deviceInfo },
+    });
+  }
+
+  /**
+   * Return and call callbacks
+   * @param event
+   * @returns
+   */
+  private emit<E extends ConnectEvent | WalletEvent>(event: E): E {
+    this.callbacks.forEach((item) => item(event));
+    return event;
+  }
+
+  /**
+   * Reconnect implementation
+   * @returns
+   */
+  async restoreConnection(): Promise<ConnectEvent> {
+    try {
+      const items = await this.provider.send<ConnectItemReply[]>(
+        'tonConnect_reconnect',
+        [{ name: 'ton_addr' }],
+      );
+
+      return this.emit({
+        event: 'connect',
+        payload: {
+          items: items,
+          device: this.deviceInfo,
+        },
+      });
+    } catch (e) {
+      if (e instanceof TonConnectError) {
+        return this.emit(formatConnectEventError(e));
+      } else {
+        return this.emit(
+          formatConnectEventError(
+            new TonConnectError((e as Error).message ?? 'Unknown error'),
+          ),
+        );
+      }
+    }
+  }
+
+  /**
+   * Send ton method tonConnect_${method}
+   * @param message
+   * @returns
+   */
+  async send(message: AppRequest): Promise<WalletResponse> {
+    try {
+      const result = await this.provider.send<string>(
+        `tonConnect_${message.method}`,
+        message.params.map((item) => JSON.parse(item)),
+      );
+
+      return { result, id: message.id.toString() };
+    } catch (e) {
+      return {
+        error: e as WalletResponseError['error'],
+        id: String(message.id),
+      };
+    }
+  }
+
+  /**
+   * Callback like listen to events
+   * @param callback
+   * @returns
+   */
+  listen = (callback: (event: WalletEvent) => void): (() => void) => {
+    this.callbacks.push(callback);
+
+    return () => {
+      this.callbacks = this.callbacks.filter((item) => item != callback);
+    };
+  };
+}

--- a/packages/ton/TonProvider.ts
+++ b/packages/ton/TonProvider.ts
@@ -1,0 +1,59 @@
+import { BaseProvider } from '@trustwallet/web3-provider-core';
+import type ITonProvider from './types/TonProvider';
+import type { ITonProviderConfig } from './types/TonProvider';
+import { MobileAdapter } from './MobileAdapter';
+
+export class TonProvider extends BaseProvider implements ITonProvider {
+  static NETWORK = 'ton';
+  private mobileAdapter!: MobileAdapter;
+
+  #version = 'v4R2';
+
+  constructor(config?: ITonProviderConfig) {
+    super();
+
+    if (config) {
+      if (config.version) {
+        this.#version = config.version;
+      }
+    }
+
+    if (!config?.disableMobileAdapter) {
+      this.mobileAdapter = new MobileAdapter(this);
+    }
+  }
+
+  isConnected(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  send<T>(method: string, params?: unknown[] | object): Promise<T> {
+    const next = () => {
+      return this.internalRequest<T>(method, params) as Promise<T>;
+    };
+
+    if (this.mobileAdapter) {
+      return this.mobileAdapter.request<T>(method, params);
+    }
+
+    return next();
+  }
+
+  internalRequest<T>(
+    method: string,
+    params: object | unknown[] | undefined,
+  ): Promise<T> {
+    return super.request<T>({
+      method,
+      params,
+    });
+  }
+
+  getNetwork(): string {
+    return TonProvider.NETWORK;
+  }
+
+  get version() {
+    return this.#version;
+  }
+}

--- a/packages/ton/exceptions/RPCError.ts
+++ b/packages/ton/exceptions/RPCError.ts
@@ -1,0 +1,13 @@
+export class RPCError extends Error {
+  code: number;
+
+  constructor(code: number, message: string) {
+    super();
+    this.code = code;
+    this.message = message;
+  }
+
+  toString() {
+    return `${this.message} (${this.code})`;
+  }
+}

--- a/packages/ton/exceptions/TonConnectError.ts
+++ b/packages/ton/exceptions/TonConnectError.ts
@@ -1,0 +1,8 @@
+export class TonConnectError extends Error {
+  code?: number;
+
+  constructor(message: string, code?: number) {
+    super(message);
+    this.code = code;
+  }
+}

--- a/packages/ton/index.ts
+++ b/packages/ton/index.ts
@@ -1,0 +1,2 @@
+export * from './TonProvider';
+export * from './TonBridge';

--- a/packages/ton/package.json
+++ b/packages/ton/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@trustwallet/web3-provider-ton",
+  "version": "4.0.0",
+  "type": "module",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.es.js",
+  "unpkg": "dist/index.umd.js",
+  "types": "dist/types/index.d.ts",
+  "author": "Trust <support@trustwallet.com>",
+  "license": "MIT",
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build:clean": "rm -rf dist",
+    "build:types": "tsc",
+    "build:source": "bun build:clean; rollup --config ./rollup.config.js; bun run build:types",
+    "dev": "bun build ./index.ts --outdir ./dist --watch"
+  },
+  "dependencies": { },
+  "devDependencies": {
+    "@trustwallet/web3-provider-core": "workspace:*"
+  }
+}

--- a/packages/ton/rollup.config.js
+++ b/packages/ton/rollup.config.js
@@ -1,0 +1,4 @@
+import { name, dependencies } from './package.json';
+import createConfig from '../../rollup.config';
+
+export default createConfig(name, Object.keys(dependencies));

--- a/packages/ton/tests/TonProvider.spec.ts
+++ b/packages/ton/tests/TonProvider.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect, jest, afterEach } from 'bun:test';
+import { Web3Provider } from '@trustwallet/web3-provider-core';
+import { TonProvider } from '../TonProvider';
+import { AdapterStrategy } from '@trustwallet/web3-provider-core/adapter/Adapter';
+import { IHandlerParams } from '@trustwallet/web3-provider-core/adapter/CallbackAdapter';
+
+let Ton = new TonProvider();
+const account = '0:123';
+
+afterEach(() => {
+  Ton = new TonProvider();
+});
+
+test('Ton Connect → tonConnect_connect', async () => {
+  new Web3Provider({
+    strategy: AdapterStrategy.PROMISES,
+    handler: () => Promise.resolve(JSON.stringify([{ address: account }])),
+  }).registerProvider(Ton);
+
+  const accounts = await Ton.send('tonConnect_connect');
+  expect(accounts).toEqual([{ address: account }]);
+});
+
+test('Ton Connect → tonConnect_connect → mobile adapter', async () => {
+  const handler = jest.fn((_params: IHandlerParams) =>
+    Promise.resolve(JSON.stringify([{ address: account }])),
+  );
+
+  new Web3Provider({
+    strategy: AdapterStrategy.PROMISES,
+    handler,
+  }).registerProvider(Ton);
+
+  await Ton.send('tonConnect_connect');
+
+  expect(handler).toHaveBeenCalledWith(
+    expect.objectContaining({ name: 'requestAccounts' }),
+  );
+});
+
+test('Ton Connect → ton_rawSign', async () => {
+  const handler = jest.fn((_params: IHandlerParams) =>
+    Promise.resolve(JSON.stringify([{ address: account }])),
+  );
+
+  new Web3Provider({
+    strategy: AdapterStrategy.PROMISES,
+    handler,
+  }).registerProvider(Ton);
+
+  await Ton.send('ton_rawSign', { message: '123' });
+
+  expect(handler).toHaveBeenCalledWith(
+    expect.objectContaining({
+      name: 'signMessage',
+      object: { message: '123' },
+    }),
+  );
+});
+
+test('Ton Connect → ton_sendTransaction', async () => {
+  const handler = jest.fn((_params: IHandlerParams) =>
+    Promise.resolve(JSON.stringify([{ address: account }])),
+  );
+
+  new Web3Provider({
+    strategy: AdapterStrategy.PROMISES,
+    handler,
+  }).registerProvider(Ton);
+
+  await Ton.send('ton_sendTransaction', { data: '123' });
+
+  expect(handler).toHaveBeenCalledWith(
+    expect.objectContaining({
+      name: 'signTransaction',
+      object: { data: '123' },
+    }),
+  );
+});
+
+test('Ton Connect → tonConnect_sendTransaction', async () => {
+  const handler = jest.fn((_params: IHandlerParams) =>
+    Promise.resolve(JSON.stringify([{ address: account }])),
+  );
+
+  new Web3Provider({
+    strategy: AdapterStrategy.PROMISES,
+    handler,
+  }).registerProvider(Ton);
+
+  await Ton.send('tonConnect_sendTransaction', { data: '123' });
+
+  expect(handler).toHaveBeenCalledWith(
+    expect.objectContaining({
+      name: 'signTransaction',
+      object: { data: '123' },
+    }),
+  );
+});
+
+test('Ton Connect → ton_requestAccounts', async () => {
+  const handler = jest.fn((_params: IHandlerParams) =>
+    Promise.resolve(JSON.stringify([{ nonBounceable: account }])),
+  );
+
+  new Web3Provider({
+    strategy: AdapterStrategy.PROMISES,
+    handler,
+  }).registerProvider(Ton);
+
+  const res = await Ton.send('ton_requestAccounts');
+
+  expect(res).toEqual([account]);
+
+  expect(handler).toHaveBeenCalledWith(
+    expect.objectContaining({
+      name: 'requestAccounts',
+    }),
+  );
+});
+
+test('Ton Connect → ton_requestWallets', async () => {
+  const handler = jest.fn((_params: IHandlerParams) =>
+    Promise.resolve(JSON.stringify([{ nonBounceable: account }])),
+  );
+
+  new Web3Provider({
+    strategy: AdapterStrategy.PROMISES,
+    handler,
+  }).registerProvider(Ton);
+
+  const res = await Ton.send('ton_requestWallets');
+
+  expect(res).toEqual([{ address: account, version: 'v4R2' }]);
+
+  expect(handler).toHaveBeenCalledWith(
+    expect.objectContaining({
+      name: 'requestAccounts',
+    }),
+  );
+});

--- a/packages/ton/tsconfig.json
+++ b/packages/ton/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["package.json", "rollup.config.js", "tsconfig.json", "tests", "./dist"],
+  "compilerOptions": {
+    "rootDir": "./",
+    "outDir": "./dist/types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/ton/types/TonBridge.ts
+++ b/packages/ton/types/TonBridge.ts
@@ -1,0 +1,137 @@
+enum NETWORK {
+  MAINNET = '-239',
+  TESTNET = '-3',
+}
+
+type Feature =
+  | { name: 'SendTransaction'; maxMessages: number } // `maxMessages` is maximum number of messages in one `SendTransaction` that the wallet supports
+  | { name: 'SignData' };
+
+export type DeviceInfo = {
+  platform: 'iphone' | 'ipad' | 'android' | 'windows' | 'mac' | 'linux';
+  appName: string; // e.g. "Tonkeeper"
+  appVersion: string; // e.g. "2.3.367"
+  maxProtocolVersion: number;
+  features: Feature[]; // list of supported features and methods in RPC
+  // Currently there is only one feature -- 'SendTransaction';
+};
+
+export interface WalletInfo {
+  name: string;
+  image: string;
+  tondns?: string;
+  about_url: string;
+}
+
+export type ConnectRequest = {
+  manifestUrl: string;
+  items: ConnectItem[]; // data items to share with the app
+};
+
+type ConnectItem = TonAddressItem | TonProofItem;
+
+type TonAddressItem = {
+  name: 'ton_addr';
+};
+
+type TonProofItem = {
+  name: 'ton_proof';
+  payload: string; // arbitrary payload, e.g. nonce + expiration timestamp.
+};
+
+// Untrusted data returned by the wallet.
+// If you need a guarantee that the user owns this address and public key, you need to additionally request a ton_proof.
+type TonAddressItemReply = {
+  name: 'ton_addr';
+  address: string; // TON address raw (`0:<hex>`)
+  network: NETWORK; // network global_id
+  publicKey: string; // HEX string without 0x
+  walletStateInit: string; // Base64 (not url safe) encoded state init cell for the wallet contract
+};
+
+type TonProofItemReply = TonProofItemReplySuccess | TonProofItemReplyError;
+
+type TonProofItemReplySuccess = {
+  name: 'ton_proof';
+  proof: {
+    timestamp: string; // 64-bit unix epoch time of the signing operation (seconds)
+    domain: {
+      lengthBytes: number; // AppDomain Length
+      value: string; // app domain name (as url part, without encoding)
+    };
+    signature: string; // base64-encoded signature
+    payload: string; // payload from the request
+  };
+};
+
+type TonProofItemReplyError = {
+  name: 'ton_addr';
+  error: {
+    code: number;
+    message?: string;
+  };
+};
+
+export type ConnectItemReply = TonAddressItemReply | TonProofItemReply;
+
+type ConnectEventSuccess = {
+  event: 'connect';
+  id?: number;
+  payload: {
+    items: ConnectItemReply[];
+    device: DeviceInfo;
+  };
+};
+
+export type ConnectEventError = {
+  event: 'connect_error';
+  id?: number;
+  payload: {
+    code: number;
+    message: string;
+  };
+};
+
+export type ConnectEvent = ConnectEventSuccess | ConnectEventError;
+
+export type WalletResponse = WalletResponseSuccess | WalletResponseError;
+
+interface WalletResponseSuccess {
+  result: string;
+  id: string;
+}
+
+export interface WalletResponseError {
+  error: { code: number; message: string; data?: unknown };
+  id: string;
+}
+
+export interface WalletEvent {
+  event: WalletEventName;
+  id?: number;
+  payload: any;
+}
+
+type WalletEventName = 'connect' | 'connect_error' | 'disconnect';
+
+export interface AppRequest {
+  method: string;
+  params: string[];
+  id: string;
+}
+
+export type TonConnectCallback = (event: WalletEvent) => void;
+
+export interface TonConnectBridge {
+  deviceInfo: DeviceInfo;
+  walletInfo?: WalletInfo;
+  protocolVersion: number;
+  isWalletBrowser: boolean;
+  connect(
+    protocolVersion: number,
+    message: ConnectRequest,
+  ): Promise<ConnectEvent>;
+  restoreConnection(): Promise<ConnectEvent>;
+  send(message: AppRequest): Promise<WalletResponse>;
+  listen(callback: (event: WalletEvent) => void): () => void;
+}

--- a/packages/ton/types/TonProvider.ts
+++ b/packages/ton/types/TonProvider.ts
@@ -1,0 +1,10 @@
+export interface ITonProviderConfig {
+  isTrust?: boolean;
+  disableMobileAdapter?: boolean;
+  version?: string;
+}
+
+export default interface ITonProvider {
+  isConnected(): Promise<boolean>;
+  send(method: string, params?: unknown[] | object): Promise<unknown>;
+}

--- a/scripts/link.ts
+++ b/scripts/link.ts
@@ -1,13 +1,15 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { execSync, exec } from 'child_process';
+import { allowedPackages } from './packages';
 
 const subpackagesDir = path.resolve(__dirname, '../packages');
 
 const directories = fs
   .readdirSync(subpackagesDir, { withFileTypes: true })
   .filter((dirent) => dirent.isDirectory())
-  .map((dirent) => dirent.name);
+  .map((dirent) => dirent.name)
+  .filter((name) => allowedPackages.includes(name));
 
 let command = `npm link `;
 

--- a/scripts/packages.ts
+++ b/scripts/packages.ts
@@ -7,4 +7,5 @@ export const allowedPackages = [
   'ethereum',
   'solana',
   'aptos',
+  'ton',
 ];


### PR DESCRIPTION

```
    ___       ___       ___   
   /\  \     /\  \     /\__\  
   \:\  \   /::\  \   /:| _|_ 
   /::\__\ /:/\:\__\ /::|/\__\
  /:/\/__/ \:\/:/  / \/|::/  /
  \/__/     \::/  /    |:/  / 
             \/__/     \/__/  
```
## Adding support for Ton Bridge & Provider

`@trustwallet/web3-provider-ton`

### Supported methods
- [x] tonConnect_connect 
- [x] tonConnect_reconnect
- [x] ton_rawSign -> signMessage
- [x] tonConnect_sendTransaction -> signTransaction
- [x] ton_sendTransaction
- [x] ton_requestAccounts
- [x] ton_requestWallets
- [x] ton_getBalance: should be supported by clients

### Not supported yet
- [ ] ton_decryptMessage
- [ ]  ton_encryptMessage

<img width="502" alt="Screenshot 2024-07-29 at 5 32 34 PM" src="https://github.com/user-attachments/assets/1c54e791-e010-4469-ba16-d3491a03994f">

