### PR TITLE
Handles connect_error on Ton connect request.

### DIFF
--- a/packages/ton/TonBridge.ts
+++ b/packages/ton/TonBridge.ts
@@ -76,11 +76,15 @@ export class TonBridge implements TonConnectBridge {
       'tonConnect_connect',
       message,
     );
-
-    return this.emit({
-      event: 'connect',
-      payload: { items, device: this.deviceInfo },
-    });
+    
+    if(items?.event === "connect_error") {
+      return this.emit(items);
+    } else {
+      return this.emit({
+        event: 'connect',
+        payload: { items, device: this.deviceInfo },
+      });
+    }
   }
 
   async disconnect() {

--- a/packages/ton/TonBridge.ts
+++ b/packages/ton/TonBridge.ts
@@ -77,7 +77,7 @@ export class TonBridge implements TonConnectBridge {
       message,
     );
     
-    if(items?.event === "connect_error") {
+    if (items?.event === "connect_error") {
       return this.emit(items);
     } else {
       return this.emit({


### PR DESCRIPTION
By protocol wallet can return connection error on connect request of DApp. In this case TonBridge implementation handle  connect_error event as payload of connect success response. It's leads to js exception on DApp side when Dapp try parse response from wallet based on event's name.

Sample of js error on DApp side:
<img width="1434" alt="Screenshot 2024-10-12 at 03 52 56" src="https://github.com/user-attachments/assets/0fb7c96e-f155-416e-8971-278dd725d239">
