### PR TITLE
fix(android-demo): use modern trustwallet provider API and inject at document start

### DIFF
--- a/android/app/src/main/java/com/trust/web3/demo/MainActivity.kt
+++ b/android/app/src/main/java/com/trust/web3/demo/MainActivity.kt
@@ -7,8 +7,13 @@ import android.webkit.SslErrorHandler
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.appcompat.app.AppCompatActivity
+import androidx.webkit.ScriptHandler
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
 
 class MainActivity : AppCompatActivity() {
+    private var documentStartScript: ScriptHandler? = null
+
     companion object {
         private const val DAPP_URL = "https://www.magiceden.io/me"
         private const val CHAIN_ID = 56
@@ -20,8 +25,8 @@ class MainActivity : AppCompatActivity() {
 
         setContentView(R.layout.activity_main)
 
-        val provderJs = loadProviderJs()
-        val initJs = loadInitJs(
+        val providerJs = loadProviderJs()
+        val bootstrapJs = loadBootstrapJs(
             CHAIN_ID,
             RPC_URL
         )
@@ -31,14 +36,22 @@ class MainActivity : AppCompatActivity() {
             javaScriptEnabled = true
             domStorageEnabled = true
         }
+
+        val hasDocumentStartInjection = installDocumentStartInjection(
+            webview,
+            providerJs,
+            bootstrapJs
+        )
+
         WebAppInterface(this, webview, DAPP_URL).run {
             webview.addJavascriptInterface(this, "_tw_")
 
             val webViewClient = object : WebViewClient() {
                 override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                     super.onPageStarted(view, url, favicon)
-                    view?.evaluateJavascript(provderJs, null)
-                    view?.evaluateJavascript(initJs, null)
+                    if (!hasDocumentStartInjection) {
+                        injectScripts(view, providerJs, bootstrapJs)
+                    }
                 }
 
                 override fun onReceivedSslError(
@@ -56,31 +69,95 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    override fun onDestroy() {
+        documentStartScript?.remove()
+        documentStartScript = null
+        super.onDestroy()
+    }
+
+    private fun installDocumentStartInjection(
+        webView: WebView,
+        providerJs: String,
+        bootstrapJs: String
+    ): Boolean {
+        if (!WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
+            return false
+        }
+
+        documentStartScript?.remove()
+        documentStartScript = WebViewCompat.addDocumentStartJavaScript(
+            webView,
+            providerJs + "\n" + bootstrapJs,
+            setOf("*")
+        )
+        return true
+    }
+
+    private fun injectScripts(view: WebView?, providerJs: String, bootstrapJs: String) {
+        view?.evaluateJavascript(providerJs) {
+            view.evaluateJavascript(bootstrapJs, null)
+        }
+    }
+
     private fun loadProviderJs(): String {
         return resources.openRawResource(R.raw.trust_min).bufferedReader().use { it.readText() }
     }
 
-    private fun loadInitJs(chainId: Int, rpcUrl: String): String {
+    private fun loadBootstrapJs(chainId: Int, rpcUrl: String): String {
         val source = """
         (function() {
-            var config = {                
+            const config = {
                 ethereum: {
                     chainId: $chainId,
                     rpcUrl: "$rpcUrl"
                 },
                 solana: {
                     cluster: "mainnet-beta",
-                },
-                isDebug: true
+                    useLegacySign: true
+                }
             };
-            trustwallet.ethereum = new trustwallet.Provider(config);
-            trustwallet.solana = new trustwallet.SolanaProvider(config);
-            trustwallet.postMessage = (json) => {
-                window._tw_.postMessage(JSON.stringify(json));
+
+            const strategy = 'CALLBACK';
+
+            try {
+                const core = trustwallet.core(strategy, (params) => {
+                    if (params.name === 'wallet_requestPermissions') {
+                        core.sendResponse(params.id, null);
+                        return;
+                    }
+
+                    window._tw_.postMessage(JSON.stringify(params));
+                });
+
+                const ethereum = trustwallet.ethereum(config.ethereum);
+                const solana = trustwallet.solana(config.solana);
+
+                core.registerProviders([ethereum, solana].map((provider) => {
+                    provider.sendResponse = core.sendResponse.bind(core);
+                    provider.sendError = core.sendError.bind(core);
+                    return provider;
+                }));
+
+                trustwallet.ethereum = ethereum;
+                trustwallet.solana = solana;
+
+                Object.assign(window.trustwallet, {
+                    isTrust: true,
+                    isTrustWallet: true,
+                    request: ethereum.request.bind(ethereum),
+                    send: ethereum.send.bind(ethereum),
+                    on: (...params) => ethereum.on(...params),
+                    off: (...params) => ethereum.off(...params),
+                });
+
+                window.ethereum = ethereum;
+                window.solana = solana;
+                window.trustWallet = window.trustwallet;
+            } catch (error) {
+                console.error('Trust Wallet Android provider bootstrap failed', error);
             }
-            window.ethereum = trustwallet.ethereum;
         })();
         """
-        return  source
+        return source
     }
 }


### PR DESCRIPTION
## Updates the Android demo bootstrap to the current `trust_min.js` API

Resolves #573 (and supersedes the previously generated draft for the same issue).

### Why the demo was broken

The demo's `MainActivity.kt` was constructing providers with the old API:

```kotlin
trustwallet.ethereum = new trustwallet.Provider(config);
trustwallet.solana   = new trustwallet.SolanaProvider(config);
```

The current `trust_min.js` bundle no longer exposes those constructors. It exposes
factory functions on a `trustwallet` namespace (`trustwallet.core`,
`trustwallet.ethereum`, `trustwallet.solana`) that must be wired through a single
`core(strategy, callback)` instance. With the old bootstrap, the dApp ended up
with an undefined / unusable `window.ethereum`.

### What this PR changes

`android/app/src/main/java/com/trust/web3/demo/MainActivity.kt`:

1. Replaces the outdated bootstrap JS with one that uses
   `trustwallet.core(...)`, `trustwallet.ethereum(...)` and `trustwallet.solana(...)`,
   registers both providers via `core.registerProviders`, and re-exposes them on
   `window.ethereum`, `window.solana` and `window.trustwallet`.
2. Installs the combined provider + bootstrap script with
   `WebViewCompat.addDocumentStartJavaScript(...)` (gated on
   `WebViewFeature.DOCUMENT_START_SCRIPT`), so the provider is injected before
   any dApp script runs. Falls back to evaluating in `onPageStarted` on older
   WebView versions.
3. Removes the document-start script in `onDestroy` to avoid leaking the handle.

This is the same approach used in the already-reviewed PR #754 for issue #740.
