### PR TITLE
fix(android): update demo provider bootstrap for injected dapps

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.2.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.webkit:webkit:1.9.0'
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 

--- a/android/app/src/main/java/com/trust/web3/demo/MainActivity.kt
+++ b/android/app/src/main/java/com/trust/web3/demo/MainActivity.kt
@@ -1,8 +1,10 @@
 package com.trust.web3.demo
 
 import android.graphics.Bitmap
+import android.net.Uri
 import android.net.http.SslError
 import android.os.Bundle
+import android.util.Log
 import android.webkit.SslErrorHandler
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -84,18 +86,47 @@ class MainActivity : AppCompatActivity() {
             return false
         }
 
+        val allowedOrigins = allowedOriginRulesForDapp(DAPP_URL)
+        if (allowedOrigins.isEmpty()) {
+            // Without a derivable origin we fall back to onPageStarted injection
+            // rather than open the provider up to every page (setOf("*")).
+            return false
+        }
+
         documentStartScript?.remove()
         documentStartScript = WebViewCompat.addDocumentStartJavaScript(
             webView,
             providerJs + "\n" + bootstrapJs,
-            setOf("*")
+            allowedOrigins
         )
         return true
     }
 
+    /**
+     * Restrict provider injection to the configured dapp's origin so the wallet
+     * provider is not exposed to arbitrary pages the WebView may navigate to
+     * (redirects, embedded frames, third-party links, etc.).
+     */
+    private fun allowedOriginRulesForDapp(dappUrl: String): Set<String> {
+        val uri = runCatching { Uri.parse(dappUrl) }.getOrNull()
+        val scheme = uri?.scheme
+        val host = uri?.host
+        if (scheme.isNullOrBlank() || host.isNullOrBlank()) {
+            Log.w("MainActivity", "Could not derive origin from DAPP_URL=$dappUrl; refusing wildcard injection")
+            return emptySet()
+        }
+        val origin = buildString {
+            append(scheme).append("://").append(host)
+            if (uri.port != -1) append(":").append(uri.port)
+        }
+        return setOf(origin)
+    }
+
     private fun injectScripts(view: WebView?, providerJs: String, bootstrapJs: String) {
-        view?.evaluateJavascript(providerJs) {
-            view.evaluateJavascript(bootstrapJs, null)
+        view?.let { webView ->
+            webView.evaluateJavascript(providerJs) {
+                webView.evaluateJavascript(bootstrapJs, null)
+            }
         }
     }
 
@@ -140,6 +171,10 @@ class MainActivity : AppCompatActivity() {
 
                 trustwallet.ethereum = ethereum;
                 trustwallet.solana = solana;
+
+                if (typeof window.trustwallet !== 'object' || window.trustwallet === null) {
+                    window.trustwallet = {};
+                }
 
                 Object.assign(window.trustwallet, {
                     isTrust: true,

--- a/android/app/src/main/java/com/trust/web3/demo/MainActivity.kt
+++ b/android/app/src/main/java/com/trust/web3/demo/MainActivity.kt
@@ -7,6 +7,7 @@ import android.webkit.SslErrorHandler
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.appcompat.app.AppCompatActivity
+import android.annotation.SuppressLint
 
 class MainActivity : AppCompatActivity() {
     companion object {
@@ -28,6 +29,7 @@ class MainActivity : AppCompatActivity() {
         WebView.setWebContentsDebuggingEnabled(true)
         val webview: WebView = findViewById(R.id.webview)
         webview.settings.run {
+            @SuppressLint("SetJavaScriptEnabled")
             javaScriptEnabled = true
             domStorageEnabled = true
         }

--- a/android/app/src/main/java/com/trust/web3/demo/MainActivity.kt
+++ b/android/app/src/main/java/com/trust/web3/demo/MainActivity.kt
@@ -7,9 +7,13 @@ import android.webkit.SslErrorHandler
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.appcompat.app.AppCompatActivity
-import android.annotation.SuppressLint
+import androidx.webkit.ScriptHandler
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
 
 class MainActivity : AppCompatActivity() {
+    private var documentStartScript: ScriptHandler? = null
+
     companion object {
         private const val DAPP_URL = "https://www.magiceden.io/me"
         private const val CHAIN_ID = 56
@@ -21,26 +25,33 @@ class MainActivity : AppCompatActivity() {
 
         setContentView(R.layout.activity_main)
 
-        val provderJs = loadProviderJs()
-        val initJs = loadInitJs(
+        val providerJs = loadProviderJs()
+        val bootstrapJs = loadBootstrapJs(
             CHAIN_ID,
             RPC_URL
         )
         WebView.setWebContentsDebuggingEnabled(true)
         val webview: WebView = findViewById(R.id.webview)
         webview.settings.run {
-            @SuppressLint("SetJavaScriptEnabled")
             javaScriptEnabled = true
             domStorageEnabled = true
         }
+
+        val hasDocumentStartInjection = installDocumentStartInjection(
+            webview,
+            providerJs,
+            bootstrapJs
+        )
+
         WebAppInterface(this, webview, DAPP_URL).run {
             webview.addJavascriptInterface(this, "_tw_")
 
             val webViewClient = object : WebViewClient() {
                 override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                     super.onPageStarted(view, url, favicon)
-                    view?.evaluateJavascript(provderJs, null)
-                    view?.evaluateJavascript(initJs, null)
+                    if (!hasDocumentStartInjection) {
+                        injectScripts(view, providerJs, bootstrapJs)
+                    }
                 }
 
                 override fun onReceivedSslError(
@@ -58,31 +69,95 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    override fun onDestroy() {
+        documentStartScript?.remove()
+        documentStartScript = null
+        super.onDestroy()
+    }
+
+    private fun installDocumentStartInjection(
+        webView: WebView,
+        providerJs: String,
+        bootstrapJs: String
+    ): Boolean {
+        if (!WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
+            return false
+        }
+
+        documentStartScript?.remove()
+        documentStartScript = WebViewCompat.addDocumentStartJavaScript(
+            webView,
+            providerJs + "\n" + bootstrapJs,
+            setOf("*")
+        )
+        return true
+    }
+
+    private fun injectScripts(view: WebView?, providerJs: String, bootstrapJs: String) {
+        view?.evaluateJavascript(providerJs) {
+            view.evaluateJavascript(bootstrapJs, null)
+        }
+    }
+
     private fun loadProviderJs(): String {
         return resources.openRawResource(R.raw.trust_min).bufferedReader().use { it.readText() }
     }
 
-    private fun loadInitJs(chainId: Int, rpcUrl: String): String {
+    private fun loadBootstrapJs(chainId: Int, rpcUrl: String): String {
         val source = """
         (function() {
-            var config = {                
+            const config = {
                 ethereum: {
                     chainId: $chainId,
                     rpcUrl: "$rpcUrl"
                 },
                 solana: {
                     cluster: "mainnet-beta",
-                },
-                isDebug: true
+                    useLegacySign: true
+                }
             };
-            trustwallet.ethereum = new trustwallet.Provider(config);
-            trustwallet.solana = new trustwallet.SolanaProvider(config);
-            trustwallet.postMessage = (json) => {
-                window._tw_.postMessage(JSON.stringify(json));
+
+            const strategy = 'CALLBACK';
+
+            try {
+                const core = trustwallet.core(strategy, (params) => {
+                    if (params.name === 'wallet_requestPermissions') {
+                        core.sendResponse(params.id, null);
+                        return;
+                    }
+
+                    window._tw_.postMessage(JSON.stringify(params));
+                });
+
+                const ethereum = trustwallet.ethereum(config.ethereum);
+                const solana = trustwallet.solana(config.solana);
+
+                core.registerProviders([ethereum, solana].map((provider) => {
+                    provider.sendResponse = core.sendResponse.bind(core);
+                    provider.sendError = core.sendError.bind(core);
+                    return provider;
+                }));
+
+                trustwallet.ethereum = ethereum;
+                trustwallet.solana = solana;
+
+                Object.assign(window.trustwallet, {
+                    isTrust: true,
+                    isTrustWallet: true,
+                    request: ethereum.request.bind(ethereum),
+                    send: ethereum.send.bind(ethereum),
+                    on: (...params) => ethereum.on(...params),
+                    off: (...params) => ethereum.off(...params),
+                });
+
+                window.ethereum = ethereum;
+                window.solana = solana;
+                window.trustWallet = window.trustwallet;
+            } catch (error) {
+                console.error('Trust Wallet Android provider bootstrap failed', error);
             }
-            window.ethereum = trustwallet.ethereum;
         })();
         """
-        return  source
+        return source
     }
 }


### PR DESCRIPTION
## Fix Android provider bootstrap for injected dapps

Resolves #740

This change updates the Android demo to match the current Trust Wallet provider bootstrap flow:
- inject `trust_min.js` and the bootstrap script at document start when the WebView supports it
- keep a fallback path that injects in order on older WebView builds
- replace the outdated `trustwallet.Provider` / `trustwallet.SolanaProvider` usage with the current `trustwallet.core(...)`, `trustwallet.ethereum(...)`, and `trustwallet.solana(...)` API
- bind `sendResponse` / `sendError` so callback-based provider requests work correctly
- expose `window.ethereum`, `window.solana`, and `window.trustWallet` consistently

Files changed:
- `android/app/src/main/java/com/trust/web3/demo/MainActivity.kt`
- `android/app/build.gradle`

Validation:
- Kotlin/IDE file diagnostics for the touched files are clean.
