### PR TITLE
fix: seed EthereumProvider #address from config on construction

### DIFF
--- a/packages/ethereum/EthereumProvider.ts
+++ b/packages/ethereum/EthereumProvider.ts
@@ -48,6 +48,14 @@ export class EthereumProvider
         this.#rpcUrl = config.rpc || config.rpcUrl!;
       }
 
+      // Seed the in-memory address from config so eth_accounts / selectedAddress
+      // returns it on a fresh page load (auto-connect for previously trusted hosts).
+      // Without this, #address stays undefined until eth_requestAccounts runs and
+      // dapps that silently call eth_accounts on load see an empty array.
+      if (config.address) {
+        this.#address = config.address;
+      }
+
       if (typeof config.overwriteMetamask !== 'undefined') {
         this.#overwriteMetamask = config.overwriteMetamask;
       }


### PR DESCRIPTION
## Summary

`EthereumProvider`'s constructor accepts an `address` field on its config object (declared in `IEthereumProviderConfig` and used by mobile hosts that inject the live wallet address into the provider snapshot at page load), but the constructor never read it. `#address` stayed `undefined` until `eth_requestAccounts` ran.

As a result, hybrid dapps (Aave, Uniswap, anything Wagmi-based) that silently call `eth_accounts` on page load to detect an existing connection received `[]` and treated the wallet as disconnected — even when the host had injected the live address into the provider config for an already-trusted host. On every refresh / re-open of the in-app browser, the user had to click "Connect Wallet" again.

This PR reads `config.address` in the constructor — same pattern as `chainId`, `rpcUrl`, etc. — so `eth_accounts` returns `[address]` for previously trusted hosts, and refreshing the page or re-opening the dapp keeps the connection without a re-prompt.

## Context

Diagnosed against SC-132437 (Trust Wallet mobile). Mobile-side instrumentation confirmed:
- The host injects the JS bundle on every main-frame load with `config.ethereum.address = "0x..."`.
- The injected `trustwallet.ethereum(config.ethereum)` call constructs the provider with the address in its config.
- But `await window.ethereum.request({ method: 'eth_accounts' })` returned `[]` — because the constructor never wired `config.address` into `#address`, and `handleStaticRequests` for `eth_accounts` reads `this.#address`.

## Test plan

- [ ] Existing `EthereumProvider.spec.ts` tests pass (the existing `eth_accounts → should be empty` and `eth_accounts → should return address` cases continue to behave correctly: empty when no config-seeded address and no prior `eth_requestAccounts`; populated after `eth_requestAccounts` either way).
- [ ] New behaviour: instantiate `new EthereumProvider({ address: "0x...", chainId: "0x1", rpcUrl: "..." })` and verify `request({ method: 'eth_accounts' })` resolves to `["0x..."]` without any `eth_requestAccounts` call. (Worth adding as a regression test before merging — happy to push a test commit if you'd like.)
- [ ] Mobile end-to-end: build packages, bump the JitPack pin in mobile-monorepo, rebuild Android & iOS, verify Aave/Uniswap auto-reconnect on refresh.