### PR TITLE
chore: make CI build-and-test only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,8 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Build packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,74 +1,28 @@
-name: Build Packages
+name: CI
+
+# Build + test only. Publication (npm/Maven to Nexus + GitHub Packages + GitHub
+# Release) lives in the private trustwallet/trust-web3-provider-releases repo and
+# is intentionally NOT performed here — this public repo holds source and CI only.
 
 on:
+  pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Override release version (e.g. 4.7.2). Leave empty to use semantic-release.'
-        required: false
-        type: string
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+permissions:
+  contents: read
 
 jobs:
-  github-release:
-    name: Github Release
+  build-test:
+    name: Build & Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: main
       - uses: oven-sh/setup-bun@v1
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@trustwallet'
-      - name: Generate version
-        id: get-next-version
-        run: |
-          bun install --frozen-lockfile
-          bun run build:version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Resolve release version
-        id: resolve-version
-        run: |
-          override="${{ inputs.version }}"
-          auto="${{ steps.get-next-version.outputs.new-release-version }}"
-          version="${override:-$auto}"
-          if [ -z "$version" ]; then
-            echo "::error::No release version available. Provide the 'version' input or push commits that trigger semantic-release."
-            exit 1
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-      - name: Set output
-        id: vars
-        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-      - name: build packages
-        run: |
-          bun install
-          bun run build:packages
-          bun run test
-          bun run rename ${{ steps.resolve-version.outputs.version }}
-          bun run publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ steps.resolve-version.outputs.version }}
-          release_name: Release ${{ steps.resolve-version.outputs.version }}
-          body: |
-            New Release 🚀
-          draft: false
-          prerelease: false
-permissions:
-  actions: write
-  contents: write
-  deployments: write
-  packages: write
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Build packages
+        run: bun run build:packages
+      - name: Test
+        run: bun run test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
 name: CI
 
-# Build + test only. Publication (npm/Maven to Nexus + GitHub Packages + GitHub
-# Release) lives in the private trustwallet/trust-web3-provider-releases repo and
-# is intentionally NOT performed here — this public repo holds source and CI only.
+# Build + test only. This repository contains source and CI; package publishing
+# and releases are handled by a separate internal pipeline and are intentionally
+# NOT performed here.
 
 on:
   pull_request:
@@ -20,6 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.11
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Build packages

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -2,31 +2,13 @@
 
 > **Important:** Before publishing, please read the [CONTRIBUTING](CONTRIBUTING.md) guide to understand the commit conventions and versioning workflow.
 
-### How to Publish
+Package publishing and releases are handled by a separate, maintainer-operated release pipeline outside this repository. This repository contains the source and CI (build + test) only — the workflow here does **not** publish packages or create releases.
 
-Packages are published automatically using a GitHub Action called **Build Packages**. This workflow is triggered manually and handles the entire release process.
+### Release process
 
-> **Important for Android and iOS:** You must build the project locally and commit the bundled files before running the action.
+1. **Open a Pull Request** with your changes.
+2. Make sure your commits follow the [commit conventions](CONTRIBUTING.md) so the version is determined correctly.
+3. **Get the PR reviewed and merged into `main`.**
+4. A maintainer triggers the release pipeline to publish the new version.
 
-#### Running the Workflow
-
-1. **Open a Pull Request** with your changes
-2. **Get the PR reviewed and merge the PR into the `main` branch**
-3. Go to the [Actions tab](../../actions) in the GitHub repository
-4. Select the **Build Packages** workflow from the left sidebar
-5. Click **Run workflow**
-6. Select the `main` branch
-7. Click **Run workflow**
-
-#### What the Workflow Does
-
-The workflow performs the following steps:
-
-1. **Checks out** the `main` branch
-2. **Installs dependencies** with Bun
-3. **Generates the next version** using semantic-release based on commit history
-4. **Builds all packages** with `bun run build:packages`
-5. **Runs tests** to ensure everything works
-6. **Renames packages** to the new version
-7. **Publishes** packages to GitHub Package Registry
-8. **Creates a GitHub Release** with the new version tag
+> **Important for Android and iOS:** You must build the project locally and commit the bundled files before a release.


### PR DESCRIPTION
## Summary
Converts the repository workflow to **build + test only**. Release publishing is handled by a separate internal pipeline and is no longer performed from this repository.

## Changes to `.github/workflows/build.yml`
- Runs on `pull_request`, `push` to `main`, and manual dispatch (previously manual-only — there was no PR CI).
- Steps: install dependencies → build packages → test.
- `permissions: contents: read`; no tokens or secrets required.
- Removed the version-resolution, packaging-publish, and release-creation steps.
- Pinned GitHub Actions to commit SHAs.

## Notes
- The required status check name changes to `Build & Test` — update any branch-protection rule that referenced the previous check name.
- `lint` is not part of CI yet; can be added in a follow-up.